### PR TITLE
Adding jekyll-privately_public

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,3 +136,6 @@
 [submodule "jekyll-swfobject"]
 	path = jekyll-swfobject
 	url = git@github.com:sectore/jekyll-swfobject.git
+[submodule "jekyll-privately_public"]
+	path = jekyll-privately_public
+	url = git@github.com:brianp/jekyll-privately_public.git


### PR DESCRIPTION
- Added submodule for jekyll-privately_public.

PrivatelyPublic is a generator that creates privately public pages. Pages secured by url obscurity.
