### PR TITLE
added jekyll-pages-directory plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -160,3 +160,6 @@
 [submodule "jekyll-gallery-tag"]
 	path = jekyll-gallery-tag
 	url = https://github.com/MartinThoma/jekyll-gallery-tag
+[submodule "jekyll-pages-directory"]
+	path = jekyll-pages-directory
+	url = git@github.com:bbakersmith/jekyll-pages-directory.git


### PR DESCRIPTION
Defines a _pages directory for page files which routes its contents relative to the project root.
