### PR TITLE
Add in jekyll-poole plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -169,3 +169,6 @@
 [submodule "jekyll-datapage_gen"]
 	path = jekyll-datapage_gen
 	url = https://github.com/avillafiorita/jekyll-datapage_gen.git
+[submodule "jekyll-poole"]
+	path = jekyll-poole
+	url = git@github.com:iamcarrico/jekyll-poole.git


### PR DESCRIPTION
A plugin to be used with the Mr. Poole Jekyll generator, but can be used outside of that for og-tags. 
